### PR TITLE
Separate OutDir and IntDir in VC project files

### DIFF
--- a/MSVC14/libiconv_dll/libiconv_dll.vcxproj
+++ b/MSVC14/libiconv_dll/libiconv_dll.vcxproj
@@ -66,23 +66,23 @@
     <_ProjectFileVersion>11.0.51106.1</_ProjectFileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
-    <IntDir>$(Configuration)\</IntDir>
+    <OutDir>..\$(Platform)\</OutDir>
+    <IntDir>obj\$(Configuration)\$(Platform)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>..\$(Platform)\</OutDir>
+    <IntDir>obj\$(Configuration)\$(Platform)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
-    <IntDir>$(Configuration)\</IntDir>
+    <OutDir>..\$(Platform)\</OutDir>
+    <IntDir>obj\$(Configuration)\$(Platform)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>..\$(Platform)\</OutDir>
+    <IntDir>obj\$(Configuration)\$(Platform)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -102,14 +102,14 @@
       <ProgramDataBaseFileName>$(IntDir)libiconv_debug.pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Link>
-      <OutputFile>Debug\libiconv_debug.dll</OutputFile>
+      <OutputFile>$(OutDir)bin\libiconv_debug.dll</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <TargetMachine>MachineX86</TargetMachine>
-      <ProgramDatabaseFile>$(IntDir)libiconv_debug.pdb</ProgramDatabaseFile>
-      <ImportLibrary>$(OutDir)libiconv_debug.lib</ImportLibrary>
+      <ProgramDatabaseFile>$(OutDir)bin\libiconv_debug.pdb</ProgramDatabaseFile>
+      <ImportLibrary>$(OutDir)lib\libiconv_debug.lib</ImportLibrary>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -132,14 +132,14 @@
       <ProgramDataBaseFileName>$(IntDir)libiconv_debug.pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Link>
-      <OutputFile>x64\Debug\libiconv_debug.dll</OutputFile>
+      <OutputFile>$(OutDir)bin\libiconv_debug.dll</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <TargetMachine>MachineX64</TargetMachine>
-      <ImportLibrary>$(OutDir)libiconv_debug.lib</ImportLibrary>
-      <ProgramDatabaseFile>$(IntDir)libiconv_debug.pdb</ProgramDatabaseFile>
+      <ImportLibrary>$(OutDir)lib\libiconv_debug.lib</ImportLibrary>
+      <ProgramDatabaseFile>$(OutDir)bin\libiconv_debug.pdb</ProgramDatabaseFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -158,7 +158,7 @@
       <ProgramDataBaseFileName>$(IntDir)libiconv.pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Link>
-      <OutputFile>Release\libiconv.dll</OutputFile>
+      <OutputFile>$(OutDir)bin\libiconv.dll</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -166,8 +166,8 @@
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <TargetMachine>MachineX86</TargetMachine>
-      <ProgramDatabaseFile>$(IntDir)libiconv.pdb</ProgramDatabaseFile>
-      <ImportLibrary>$(OutDir)libiconv.lib</ImportLibrary>
+      <ProgramDatabaseFile>$(OutDir)bin\libiconv.pdb</ProgramDatabaseFile>
+      <ImportLibrary>$(OutDir)lib\libiconv.lib</ImportLibrary>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -189,7 +189,7 @@
       <ProgramDataBaseFileName>$(IntDir)libiconv.pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Link>
-      <OutputFile>x64\Release\libiconv.dll</OutputFile>
+      <OutputFile>$(OutDir)bin\libiconv.dll</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -197,8 +197,8 @@
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <TargetMachine>MachineX64</TargetMachine>
-      <ImportLibrary>$(OutDir)libiconv.lib</ImportLibrary>
-      <ProgramDatabaseFile>$(IntDir)libiconv.pdb</ProgramDatabaseFile>
+      <ImportLibrary>$(OutDir)lib\libiconv.lib</ImportLibrary>
+      <ProgramDatabaseFile>$(OutDir)bin\libiconv.pdb</ProgramDatabaseFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/MSVC14/libiconv_static/libiconv_static.vcxproj
+++ b/MSVC14/libiconv_static/libiconv_static.vcxproj
@@ -66,20 +66,20 @@
     <_ProjectFileVersion>11.0.51106.1</_ProjectFileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
-    <IntDir>$(Configuration)\</IntDir>
+    <OutDir>..\$(Platform)\</OutDir>
+    <IntDir>obj\$(Configuration)\$(Platform)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>..\$(Platform)\</OutDir>
+    <IntDir>obj\$(Configuration)\$(Platform)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
-    <IntDir>$(Configuration)\</IntDir>
+    <OutDir>..\$(Platform)\</OutDir>
+    <IntDir>obj\$(Configuration)\$(Platform)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>..\$(Platform)\</OutDir>
+    <IntDir>obj\$(Configuration)\$(Platform)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
@@ -95,10 +95,10 @@
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <ProgramDataBaseFileName>$(IntDir)libiconv_a_debug.pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(OutDir)lib\libiconv_a_debug.pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Lib>
-      <OutputFile>Debug\libiconv_a_debug.lib</OutputFile>
+      <OutputFile>$(OutDir)lib\libiconv_a_debug.lib</OutputFile>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -118,10 +118,10 @@
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <ProgramDataBaseFileName>$(IntDir)libiconv_a_debug.pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(OutDir)lib\libiconv_a_debug.pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Lib>
-      <OutputFile>x64\Debug\libiconv_a_debug.lib</OutputFile>
+      <OutputFile>$(OutDir)lib\libiconv_a_debug.lib</OutputFile>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -137,10 +137,10 @@
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <ProgramDataBaseFileName>$(IntDir)libiconv_a.pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(OutDir)lib\libiconv_a.pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Lib>
-      <OutputFile>Release\libiconv_a.lib</OutputFile>
+      <OutputFile>$(OutDir)lib\libiconv_a.lib</OutputFile>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -159,10 +159,10 @@
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <ProgramDataBaseFileName>$(IntDir)libiconv_a.pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(OutDir)lib\libiconv_a.pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Lib>
-      <OutputFile>x64\Release\libiconv_a.lib</OutputFile>
+      <OutputFile>$(OutDir)lib\libiconv_a.lib</OutputFile>
     </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/MSVC14/vc14.bat
+++ b/MSVC14/vc14.bat
@@ -1,0 +1,6 @@
+msbuild libiconv.sln /t:Rebuild /p:Configuration=Release /p:Platform=Win32 
+msbuild libiconv.sln /t:Rebuild /p:Configuration=Debug /p:Platform=Win32 
+xcopy ..\source\include\iconv.h Win32\include\
+msbuild libiconv.sln /t:Rebuild /p:Configuration=Release /p:Platform=x64 
+msbuild libiconv.sln /t:Rebuild /p:Configuration=Debug /p:Platform=x64 
+xcopy ..\source\include\iconv.h x64\include\

--- a/MSVC15/libiconv_dll/libiconv_dll.vcxproj
+++ b/MSVC15/libiconv_dll/libiconv_dll.vcxproj
@@ -66,23 +66,23 @@
     <_ProjectFileVersion>11.0.51106.1</_ProjectFileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
-    <IntDir>$(Configuration)\</IntDir>
+    <OutDir>..\$(Platform)\</OutDir>
+    <IntDir>obj\$(Configuration)\$(Platform)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>..\$(Platform)\</OutDir>
+    <IntDir>obj\$(Configuration)\$(Platform)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
-    <IntDir>$(Configuration)\</IntDir>
+    <OutDir>..\$(Platform)\</OutDir>
+    <IntDir>obj\$(Configuration)\$(Platform)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>..\$(Platform)\</OutDir>
+    <IntDir>obj\$(Configuration)\$(Platform)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -102,14 +102,14 @@
       <ProgramDataBaseFileName>$(IntDir)libiconv_debug.pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Link>
-      <OutputFile>Debug\libiconv_debug.dll</OutputFile>
+      <OutputFile>$(OutDir)bin\libiconv_debug.dll</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <TargetMachine>MachineX86</TargetMachine>
-      <ProgramDatabaseFile>$(IntDir)libiconv_debug.pdb</ProgramDatabaseFile>
-      <ImportLibrary>$(OutDir)libiconv_debug.lib</ImportLibrary>
+      <ProgramDatabaseFile>$(OutDir)bin\libiconv_debug.pdb</ProgramDatabaseFile>
+      <ImportLibrary>$(OutDir)lib\libiconv_debug.lib</ImportLibrary>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -132,14 +132,14 @@
       <ProgramDataBaseFileName>$(IntDir)libiconv_debug.pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Link>
-      <OutputFile>x64\Debug\libiconv_debug.dll</OutputFile>
+      <OutputFile>$(OutDir)bin\libiconv_debug.dll</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <TargetMachine>MachineX64</TargetMachine>
-      <ImportLibrary>$(OutDir)libiconv_debug.lib</ImportLibrary>
-      <ProgramDatabaseFile>$(IntDir)libiconv_debug.pdb</ProgramDatabaseFile>
+      <ImportLibrary>$(OutDir)lib\libiconv_debug.lib</ImportLibrary>
+      <ProgramDatabaseFile>$(OutDir)bin\libiconv_debug.pdb</ProgramDatabaseFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -158,7 +158,7 @@
       <ProgramDataBaseFileName>$(IntDir)libiconv.pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Link>
-      <OutputFile>Release\libiconv.dll</OutputFile>
+      <OutputFile>$(OutDir)bin\libiconv.dll</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -166,8 +166,8 @@
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <TargetMachine>MachineX86</TargetMachine>
-      <ProgramDatabaseFile>$(IntDir)libiconv.pdb</ProgramDatabaseFile>
-      <ImportLibrary>$(OutDir)libiconv.lib</ImportLibrary>
+      <ProgramDatabaseFile>$(OutDir)bin\libiconv.pdb</ProgramDatabaseFile>
+      <ImportLibrary>$(OutDir)lib\libiconv.lib</ImportLibrary>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -189,7 +189,7 @@
       <ProgramDataBaseFileName>$(IntDir)libiconv.pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Link>
-      <OutputFile>x64\Release\libiconv.dll</OutputFile>
+      <OutputFile>$(OutDir)bin\libiconv.dll</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -197,8 +197,8 @@
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <TargetMachine>MachineX64</TargetMachine>
-      <ImportLibrary>$(OutDir)libiconv.lib</ImportLibrary>
-      <ProgramDatabaseFile>$(IntDir)libiconv.pdb</ProgramDatabaseFile>
+      <ImportLibrary>$(OutDir)lib\libiconv.lib</ImportLibrary>
+      <ProgramDatabaseFile>$(OutDir)bin\libiconv.pdb</ProgramDatabaseFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/MSVC15/libiconv_static/libiconv_static.vcxproj
+++ b/MSVC15/libiconv_static/libiconv_static.vcxproj
@@ -66,20 +66,20 @@
     <_ProjectFileVersion>11.0.51106.1</_ProjectFileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
-    <IntDir>$(Configuration)\</IntDir>
+    <OutDir>..\$(Platform)\</OutDir>
+    <IntDir>obj\$(Configuration)\$(Platform)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>..\$(Platform)\</OutDir>
+    <IntDir>obj\$(Configuration)\$(Platform)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
-    <IntDir>$(Configuration)\</IntDir>
+    <OutDir>..\$(Platform)\</OutDir>
+    <IntDir>obj\$(Configuration)\$(Platform)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>..\$(Platform)\</OutDir>
+    <IntDir>obj\$(Configuration)\$(Platform)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
@@ -95,10 +95,10 @@
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <ProgramDataBaseFileName>$(IntDir)libiconv_a_debug.pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(OutDir)lib\libiconv_a_debug.pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Lib>
-      <OutputFile>Debug\libiconv_a_debug.lib</OutputFile>
+      <OutputFile>$(OutDir)lib\libiconv_a_debug.lib</OutputFile>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -118,10 +118,10 @@
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <ProgramDataBaseFileName>$(IntDir)libiconv_a_debug.pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(OutDir)lib\libiconv_a_debug.pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Lib>
-      <OutputFile>x64\Debug\libiconv_a_debug.lib</OutputFile>
+      <OutputFile>$(OutDir)lib\libiconv_a_debug.lib</OutputFile>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -137,10 +137,10 @@
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <ProgramDataBaseFileName>$(IntDir)libiconv_a.pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(OutDir)lib\libiconv_a.pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Lib>
-      <OutputFile>Release\libiconv_a.lib</OutputFile>
+      <OutputFile>$(OutDir)lib\libiconv_a.lib</OutputFile>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -159,10 +159,10 @@
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <ProgramDataBaseFileName>$(IntDir)libiconv_a.pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(OutDir)lib\libiconv_a.pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Lib>
-      <OutputFile>x64\Release\libiconv_a.lib</OutputFile>
+      <OutputFile>$(OutDir)lib\libiconv_a.lib</OutputFile>
     </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/MSVC15/libiconv_static/libiconv_static.vcxproj
+++ b/MSVC15/libiconv_static/libiconv_static.vcxproj
@@ -22,7 +22,6 @@
     <ProjectGuid>{F9C13A95-C7EB-40F3-A599-3695C1E0CF38}</ProjectGuid>
     <RootNamespace>libiconv_static</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/MSVC15/vc15.bat
+++ b/MSVC15/vc15.bat
@@ -1,0 +1,6 @@
+msbuild libiconv.sln /t:Rebuild /p:Configuration=Release /p:Platform=Win32 
+msbuild libiconv.sln /t:Rebuild /p:Configuration=Debug /p:Platform=Win32 
+xcopy ..\source\include\iconv.h Win32\include\
+msbuild libiconv.sln /t:Rebuild /p:Configuration=Release /p:Platform=x64 
+msbuild libiconv.sln /t:Rebuild /p:Configuration=Debug /p:Platform=x64 
+xcopy ..\source\include\iconv.h x64\include\


### PR DESCRIPTION
@weltling 
This fixes https://github.com/winlibs/libiconv/issues/3 and organizes the output to easily create zip files like http://windows.php.net/downloads/php-sdk/deps/vc15/x64/libiconv-1.15-1-vc15-x64.zip